### PR TITLE
Changed geom type to sphere for single contact while solving

### DIFF
--- a/mpc_python/models/mushr/cars/base_car/buddy.xml
+++ b/mpc_python/models/mushr/cars/base_car/buddy.xml
@@ -7,7 +7,7 @@
   </asset>
   <default>
       <default class="buddy_wheel">
-      <geom fitscale="1.2" type="ellipsoid" friction="2 0.005 0.0001" contype="1" conaffinity="0" mesh="buddy_mushr_wheel" mass="0.498952"/>
+      <geom fitscale="1.2" type="sphere" friction="2 0.005 0.0001" contype="1" conaffinity="0" mesh="buddy_mushr_wheel" mass="0.498952"/>
     </default>
     <default class="buddy_steering">
       <joint type="hinge" axis="0 0 1" limited="true" frictionloss="0.01" damping="0.001" armature="0.0002" range="-0.38 0.38"/>


### PR DESCRIPTION
In the latest version of mujoco, the ellipsoid is making multiple contacts which will throw an error, so i have changed the ellipsoid to sphere to ensure single contact.

Is there a better way to solve this issue ? 