### PR TITLE
fix  cvxpy 1.8.2 compatibility

### DIFF
--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -6,6 +6,7 @@ import cvxpy as opt
 import numpy as np
 import numpy.typing as npt
 import yaml
+import scipy.linalg
 
 
 class MPC:
@@ -97,13 +98,18 @@ class MPC:
         # self.r_matrix: npt.NDArray[np.float64] = np.diag(input_cost_weights)
         # self.rr_matrix: npt.NDArray[np.float64] = np.diag(input_rate_cost_weights)
 
-        self.q_matrix: npt.NDArray[np.float64] = np.diag(np.sqrt(state_cost_weights))
-        self.qf_matrix: npt.NDArray[np.float64] = np.diag(
-            np.sqrt(terminal_cost_weights)
+        # NOTE: we use sum_squares wich is not the same as a quad form
+        self.q_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+            np.diag(state_cost_weights)
         )
-        self.r_matrix: npt.NDArray[np.float64] = np.diag(np.sqrt(input_cost_weights))
-        self.rr_matrix: npt.NDArray[np.float64] = np.diag(
-            np.sqrt(input_rate_cost_weights)
+        self.qf_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+            np.diag(terminal_cost_weights)
+        )
+        self.r_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+            np.diag(input_cost_weights)
+        )
+        self.rr_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+            np.diag(input_rate_cost_weights)
         )
 
         self._safety_margin: float = obstacle_config["safety_margin"]
@@ -464,10 +470,14 @@ class MPC:
 
             self._problem.solve(
                 solver=opt.CLARABEL,
+                enforce_dpp=True,
                 warm_start=True,
                 verbose=verbose,
                 canon_backend=opt.SCIPY_CANON_BACKEND,
-                enforce_dpp=True,
+                tol_gap_abs=1e-3,  # Loosen absolute duality gap tolerance
+                tol_gap_rel=1e-3,  # Loosen relative duality gap tolerance
+                tol_feas=1e-3,  # Loosen feasibility tolerance
+                max_iter=25,  # Hard cap on interior-point iterations
             )
 
             if self._states.value is None:

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -477,10 +477,9 @@ class MPC:
                 warm_start=True,
                 verbose=verbose,
                 canon_backend=opt.SCIPY_CANON_BACKEND,
-                tol_gap_abs=1e-3,  # Loosen absolute duality gap tolerance
-                tol_gap_rel=1e-3,  # Loosen relative duality gap tolerance
-                tol_feas=1e-3,  # Loosen feasibility tolerance
-                max_iter=25,  # Hard cap on interior-point iterations
+                tol_gap_abs=1e-3,  # relax tolerances
+                tol_gap_rel=1e-3,
+                tol_feas=1e-3,
             )
 
             if self._states.value is None:

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -265,7 +265,6 @@ class MPC:
                     self._states[3, k] - self._heading_reference[k],
                 ]
             )
-            # cost += opt.quad_form(error, self.q_matrix)
             cost += opt.sum_squares(self.q_matrix @ error)
             # Obstacle half-plane constraint:
             # obstacle avoidance: (px - pobs)*2 > R  in non-convex :(
@@ -291,19 +290,12 @@ class MPC:
             ]
             cost += self._slack_penalty * self._obstacle_slack[k]
 
-            # cost += opt.quad_form(self._controls[:, k], self.r_matrix)
             cost += opt.sum_squares(self.r_matrix @ self._controls[:, k])
             if k == 0:
-                # cost += opt.quad_form(
-                #    self._controls[:, 0] - self._last_command, self.rr_matrix
-                # )
                 cost += opt.sum_squares(
                     self.rr_matrix @ (self._controls[:, 0] - self._last_command)
                 )
             else:
-                # cost += opt.quad_form(
-                #     self._controls[:, k] - self._controls[:, k - 1], self.rr_matrix
-                # )
                 cost += opt.sum_squares(
                     self.rr_matrix @ (self._controls[:, k] - self._controls[:, k - 1])
                 )
@@ -325,23 +317,25 @@ class MPC:
                 self._states[3, -1] - self._heading_reference[-1],
             ]
         )
-        # cost += opt.quad_form(terminal_error, self.qf_matrix)
         cost += opt.sum_squares(self.qf_matrix @ terminal_error)
+
+        # initial state
         constraints += [self._states[:, 0] == self._initial_state]
 
+        # state bounds
         constraints += [opt.abs(self._states[2, :]) <= self.max_speed]
 
+        # actuation bounds
         constraints += [opt.abs(self._controls[0, :]) <= self.max_acc]
         constraints += [opt.abs(self._controls[1, :]) <= self.max_steer]
-
         for k in range(1, self.control_horizon):
             constraints += [
-                opt.abs(self._controls[0, k] - self._controls[0, k - 1]) / self.dt
-                <= self.max_d_acc
+                opt.abs(self._controls[0, k] - self._controls[0, k - 1])
+                <= self.max_d_acc * self.dt
             ]
             constraints += [
-                opt.abs(self._controls[1, k] - self._controls[1, k - 1]) / self.dt
-                <= self.max_d_steer
+                opt.abs(self._controls[1, k] - self._controls[1, k - 1])
+                <= self.max_d_steer * self.dt
             ]
 
         problem = opt.Problem(opt.Minimize(cost), constraints)

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -6,7 +6,6 @@ import cvxpy as opt
 import numpy as np
 import numpy.typing as npt
 import yaml
-import scipy.linalg
 
 
 class MPC:
@@ -93,23 +92,15 @@ class MPC:
                 f"{self._control_dim}"
             )
 
-        # self.q_matrix: npt.NDArray[np.float64] = np.diag(state_cost_weights)
-        # self.qf_matrix: npt.NDArray[np.float64] = np.diag(terminal_cost_weights)
-        # self.r_matrix: npt.NDArray[np.float64] = np.diag(input_cost_weights)
-        # self.rr_matrix: npt.NDArray[np.float64] = np.diag(input_rate_cost_weights)
-
-        # NOTE: we use sum_squares wich is not the same as a quad_form(x,Q)
-        # To use sum_squares correctly, you need to pass it a matrix A such that A^T A = Q
-        self.q_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
-            np.diag(state_cost_weights)
-        )
-        self.qf_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+        # NOTE: we use sum_squares wich is not the same as a quad_form(x,Q), this is for strict DDP compliance
+        # But to use sum_squares correctly, you need to pass it a matrix A such that A^T A = Q
+        # We can get away with sqrt because matrices are diagonal
+        self.q_matrix: npt.NDArray[np.float64] = np.sqrt(np.diag(state_cost_weights))
+        self.qf_matrix: npt.NDArray[np.float64] = np.sqrt(
             np.diag(terminal_cost_weights)
         )
-        self.r_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
-            np.diag(input_cost_weights)
-        )
-        self.rr_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
+        self.r_matrix: npt.NDArray[np.float64] = np.sqrt(np.diag(input_cost_weights))
+        self.rr_matrix: npt.NDArray[np.float64] = np.sqrt(
             np.diag(input_rate_cost_weights)
         )
 

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -98,7 +98,8 @@ class MPC:
         # self.r_matrix: npt.NDArray[np.float64] = np.diag(input_cost_weights)
         # self.rr_matrix: npt.NDArray[np.float64] = np.diag(input_rate_cost_weights)
 
-        # NOTE: we use sum_squares wich is not the same as a quad form
+        # NOTE: we use sum_squares wich is not the same as a quad_form(x,Q)
+        # To use sum_squares correctly, you need to pass it a matrix A such that A^T A = Q
         self.q_matrix: npt.NDArray[np.float64] = scipy.linalg.cholesky(
             np.diag(state_cost_weights)
         )

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -92,10 +92,19 @@ class MPC:
                 f"{self._control_dim}"
             )
 
-        self.q_matrix: npt.NDArray[np.float64] = np.diag(state_cost_weights)
-        self.qf_matrix: npt.NDArray[np.float64] = np.diag(terminal_cost_weights)
-        self.r_matrix: npt.NDArray[np.float64] = np.diag(input_cost_weights)
-        self.rr_matrix: npt.NDArray[np.float64] = np.diag(input_rate_cost_weights)
+        # self.q_matrix: npt.NDArray[np.float64] = np.diag(state_cost_weights)
+        # self.qf_matrix: npt.NDArray[np.float64] = np.diag(terminal_cost_weights)
+        # self.r_matrix: npt.NDArray[np.float64] = np.diag(input_cost_weights)
+        # self.rr_matrix: npt.NDArray[np.float64] = np.diag(input_rate_cost_weights)
+
+        self.q_matrix: npt.NDArray[np.float64] = np.diag(np.sqrt(state_cost_weights))
+        self.qf_matrix: npt.NDArray[np.float64] = np.diag(
+            np.sqrt(terminal_cost_weights)
+        )
+        self.r_matrix: npt.NDArray[np.float64] = np.diag(np.sqrt(input_cost_weights))
+        self.rr_matrix: npt.NDArray[np.float64] = np.diag(
+            np.sqrt(input_rate_cost_weights)
+        )
 
         self._safety_margin: float = obstacle_config["safety_margin"]
         self._slack_penalty: float = (
@@ -249,8 +258,8 @@ class MPC:
                     self._states[3, k] - self._heading_reference[k],
                 ]
             )
-            cost += opt.quad_form(error, self.q_matrix)
-
+            # cost += opt.quad_form(error, self.q_matrix)
+            cost += opt.sum_squares(self.q_matrix @ error)
             # Obstacle half-plane constraint:
             # obstacle avoidance: (px - pobs)*2 > R  in non-convex :(
             # this is linearised as : dot(px - pbos, n) > R
@@ -275,17 +284,22 @@ class MPC:
             ]
             cost += self._slack_penalty * self._obstacle_slack[k]
 
-            cost += opt.quad_form(self._controls[:, k], self.r_matrix)
-
+            # cost += opt.quad_form(self._controls[:, k], self.r_matrix)
+            cost += opt.sum_squares(self.r_matrix @ self._controls[:, k])
             if k == 0:
-                cost += opt.quad_form(
-                    self._controls[:, 0] - self._last_command, self.rr_matrix
+                # cost += opt.quad_form(
+                #    self._controls[:, 0] - self._last_command, self.rr_matrix
+                # )
+                cost += opt.sum_squares(
+                    self.rr_matrix @ (self._controls[:, 0] - self._last_command)
                 )
             else:
-                cost += opt.quad_form(
-                    self._controls[:, k] - self._controls[:, k - 1], self.rr_matrix
+                # cost += opt.quad_form(
+                #     self._controls[:, k] - self._controls[:, k - 1], self.rr_matrix
+                # )
+                cost += opt.sum_squares(
+                    self.rr_matrix @ (self._controls[:, k] - self._controls[:, k - 1])
                 )
-
         terminal_along_track_error = (
             self._cos_reference[-1] * self._states[0, -1]
             + self._sin_reference[-1] * self._states[1, -1]
@@ -304,8 +318,8 @@ class MPC:
                 self._states[3, -1] - self._heading_reference[-1],
             ]
         )
-        cost += opt.quad_form(terminal_error, self.qf_matrix)
-
+        # cost += opt.quad_form(terminal_error, self.qf_matrix)
+        cost += opt.sum_squares(self.qf_matrix @ terminal_error)
         constraints += [self._states[:, 0] == self._initial_state]
 
         constraints += [opt.abs(self._states[2, :]) <= self.max_speed]
@@ -313,14 +327,6 @@ class MPC:
         constraints += [opt.abs(self._controls[0, :]) <= self.max_acc]
         constraints += [opt.abs(self._controls[1, :]) <= self.max_steer]
 
-        constraints += [
-            opt.abs(self._controls[0, 0] - self._last_command[0]) / self.dt
-            <= self.max_d_acc
-        ]
-        constraints += [
-            opt.abs(self._controls[1, 0] - self._last_command[1]) / self.dt
-            <= self.max_d_steer
-        ]
         for k in range(1, self.control_horizon):
             constraints += [
                 opt.abs(self._controls[0, k] - self._controls[0, k - 1]) / self.dt

--- a/mpc_python/cvxpy_mpc/cvxpy_mpc.py
+++ b/mpc_python/cvxpy_mpc/cvxpy_mpc.py
@@ -328,6 +328,14 @@ class MPC:
         # actuation bounds
         constraints += [opt.abs(self._controls[0, :]) <= self.max_acc]
         constraints += [opt.abs(self._controls[1, :]) <= self.max_steer]
+        constraints += [
+            opt.abs(self._controls[0, 0] - self._last_command[0])
+            <= self.max_d_acc * self.dt
+        ]
+        constraints += [
+            opt.abs(self._controls[1, 0] - self._last_command[1])
+            <= self.max_d_steer * self.dt
+        ]
         for k in range(1, self.control_horizon):
             constraints += [
                 opt.abs(self._controls[0, k] - self._controls[0, k - 1])


### PR DESCRIPTION
after bumping
```
>>> cvxpy.__version__
'1.8.2'
```

this shows up
```
cvxpy.error.DPPError: You are solving a parameterized problem that is not DPP. Because the problem is not DPP, subsequent solves will not be faster than the first one. For more information, see the documentation on Disciplined Parametrized Programming, at https://www.cvxpy.org/tutorial/dpp/index.html
```